### PR TITLE
typo fixed in usuarios.yaml file, but swagger.yaml must be fixed in local

### DIFF
--- a/02-open-api/endpoints/usuarios.yaml
+++ b/02-open-api/endpoints/usuarios.yaml
@@ -88,7 +88,7 @@ paths:
                       type: string
                 esResponsable:
                   type: boolean
-                esPropenente:
+                esProponente:
                   type: boolean
                 esAutorizante:
                   type: boolean
@@ -172,7 +172,7 @@ paths:
                       type: string
                 esResponsable:
                   type: boolean
-                esPropenente:
+                esProponente:
                   type: boolean
                 esAutorizante:
                   type: boolean
@@ -227,7 +227,7 @@ components:
               type: string
         esResponsable:
           type: boolean
-        esPropenente:
+        esProponente:
           type: boolean
         esAutorizante:
           type: boolean


### PR DESCRIPTION
I have fixed the typo in the 'usuarios.yaml' file. However if someone has creater the 'swagger.yaml' file, in the dist directory before this branch is merged, they will have to correct it locally because the folder dist is in .gitignore