### PR TITLE
Proyecto GEX-property 'codigo' added

### DIFF
--- a/02-open-api/endpoints/lookups.yaml
+++ b/02-open-api/endpoints/lookups.yaml
@@ -56,6 +56,10 @@ components:
         nombre:
           type: string
           description: Nombre del elemento
+        codigo:
+          type: string
+          description: Código asociado al elemento (opcional)
+          nullable: true
     UnidadesRoles:
       type: object
       properties:


### PR DESCRIPTION
property 'codigo' was added to lookup as string, and optional (nullable)